### PR TITLE
Remove unnecessary nullable reference types from DTOs and settings classes

### DIFF
--- a/src/Core/Application/Identity/Users/Password/ResetPasswordRequest.cs
+++ b/src/Core/Application/Identity/Users/Password/ResetPasswordRequest.cs
@@ -2,9 +2,9 @@
 
 public class ResetPasswordRequest
 {
-    public string? Email { get; set; }
+    public string Email { get; set; } = default!;
 
-    public string? Password { get; set; }
+    public string Password { get; set; } = default!;
 
-    public string? Token { get; set; }
+    public string Token { get; set; } = default!;
 }

--- a/src/Core/Application/Identity/Users/ToggleUserStatusRequest.cs
+++ b/src/Core/Application/Identity/Users/ToggleUserStatusRequest.cs
@@ -3,5 +3,5 @@
 public class ToggleUserStatusRequest
 {
     public bool ActivateUser { get; set; }
-    public string? UserId { get; set; }
+    public string UserId { get; set; } = default!;
 }

--- a/src/Infrastructure/Auth/Jwt/JwtSettings.cs
+++ b/src/Infrastructure/Auth/Jwt/JwtSettings.cs
@@ -2,7 +2,7 @@
 
 public class JwtSettings
 {
-    public string? Key { get; set; }
+    public string Key { get; set; } = string.Empty;
 
     public int TokenExpirationInMinutes { get; set; }
 

--- a/src/Infrastructure/BackgroundJobs/HangfireStorageSettings.cs
+++ b/src/Infrastructure/BackgroundJobs/HangfireStorageSettings.cs
@@ -2,6 +2,6 @@
 
 public class HangfireStorageSettings
 {
-    public string? StorageProvider { get; set; }
-    public string? ConnectionString { get; set; }
+    public string StorageProvider { get; set; } = string.Empty;
+    public string ConnectionString { get; set; } = string.Empty;
 }

--- a/src/Infrastructure/BackgroundJobs/Startup.cs
+++ b/src/Infrastructure/BackgroundJobs/Startup.cs
@@ -33,13 +33,13 @@ internal static class Startup
 
         if (string.IsNullOrEmpty(storageSettings!.StorageProvider))
             throw new ConfigurationErrorsException("Hangfire Storage Provider is not configured.");
-        if (string.IsNullOrEmpty(storageSettings!.ConnectionString))
+        if (string.IsNullOrEmpty(storageSettings.ConnectionString))
             throw new ConfigurationErrorsException(
                 "Hangfire Storage Provider ConnectionString is not configured."
             );
         Logger.Information(
             "Hangfire: Current Storage Provider : {StorageProvider}",
-            storageSettings!.StorageProvider
+            storageSettings.StorageProvider
         );
         Logger.Information(
             "For more Hangfire storage, visit https://www.hangfire.io/extensions.html"

--- a/src/Infrastructure/Identity/UserService.Password.cs
+++ b/src/Infrastructure/Identity/UserService.Password.cs
@@ -38,7 +38,7 @@ internal partial class UserService
 
     public async Task<string> ResetPasswordAsync(ResetPasswordRequest request)
     {
-        var user = await userManager.FindByEmailAsync(request.Email?.Normalize());
+        var user = await userManager.FindByEmailAsync(request.Email.Normalize());
 
         // Don't reveal that the user does not exist
         _ = user ?? throw new InternalServerException(localizer["An Error has occurred!"]);

--- a/src/Infrastructure/Middleware/ErrorResult.cs
+++ b/src/Infrastructure/Middleware/ErrorResult.cs
@@ -2,7 +2,7 @@
 
 public class ErrorResult
 {
-    public List<string>? Messages { get; set; } = new();
+    public List<string> Messages { get; set; } = new();
 
     public string? Source { get; set; }
     public string? Exception { get; set; }

--- a/src/Infrastructure/Middleware/ExceptionMiddleware.cs
+++ b/src/Infrastructure/Middleware/ExceptionMiddleware.cs
@@ -40,7 +40,7 @@ internal class ExceptionMiddleware(
                 ErrorId = errorId,
                 SupportMessage = localizer["exceptionmiddleware.supportmessage"],
             };
-            errorResult.Messages!.Add(exception.Message);
+            errorResult.Messages.Add(exception.Message);
             var response = context.Response;
             response.ContentType = "application/json";
             if (exception is not CustomException && exception.InnerException != null)

--- a/src/Infrastructure/Persistence/Context/BaseDbContext.cs
+++ b/src/Infrastructure/Persistence/Context/BaseDbContext.cs
@@ -61,7 +61,7 @@ public abstract class BaseDbContext(
         )
         {
             optionsBuilder.UseDatabase(
-                _dbSettings.DbProvider!,
+                _dbSettings.DbProvider,
                 _currentTenantAccessor.MultiTenantContext.TenantInfo.ConnectionString
             );
         }

--- a/src/Infrastructure/Persistence/DatabaseSettings.cs
+++ b/src/Infrastructure/Persistence/DatabaseSettings.cs
@@ -2,6 +2,6 @@
 
 public class DatabaseSettings
 {
-    public string? DbProvider { get; set; }
-    public string? ConnectionString { get; set; }
+    public string DbProvider { get; set; } = string.Empty;
+    public string ConnectionString { get; set; } = string.Empty;
 }


### PR DESCRIPTION
Properties that are always required (request DTOs, config settings) or always
initialized (ErrorResult.Messages) no longer use nullable types. Also removes
redundant null-forgiving operators at usage sites.

https://claude.ai/code/session_01JrEDUxtuBEgSEMzzwJ7mnh