### PR TITLE
fix: resolve 8 repo issues found in quality audit

### DIFF
--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -3,6 +3,7 @@
   "tasks": [
     {
       "name": "Run csharpier",
+      "group": "csharpier",
       "command": "csharpier",
       "args": [
         "format",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,19 +44,19 @@ Never add references that violate this direction (e.g., Domain referencing Appli
 | Category | Technology |
 |---|---|
 | Framework | .NET 10.0, ASP.NET Core, C# 14 |
-| ORM | Entity Framework Core 9 + Npgsql |
+| ORM | Entity Framework Core 10 + Npgsql |
 | Database | PostgreSQL 15+ |
 | CQRS | MediatR 11 |
 | Validation | FluentValidation 12 |
-| Mapping | Mapster 7 |
+| Mapping | Mapster 10 |
 | Auth | ASP.NET Core Identity, JWT Bearer, Azure AD (Microsoft.Identity.Web) |
-| Multitenancy | Finbuckle.MultiTenant 9 |
+| Multitenancy | Finbuckle.MultiTenant 10 |
 | Background Jobs | Hangfire 1.8 + Hangfire.PostgreSql |
 | Caching | Redis (StackExchangeRedis) |
 | Real-time | SignalR |
 | API Docs | NSwag 14 (OpenAPI/Swagger) |
-| Logging | Serilog 9 |
-| Testing | xUnit 2.9, FluentAssertions 8, coverlet |
+| Logging | Serilog (Extensions 10) |
+| Testing | xUnit v3 3.x, FluentAssertions 8, coverlet |
 | Code Style | StyleCop.Analyzers, Roslynator, csharpier |
 | Git Hooks | Husky.Net |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ further defined and clarified by project maintainers.
 ### Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at `hello@codewithmukesh.com` . All
+reported by opening an issue in this repository. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -67,4 +67,4 @@ from the root project folder and if everything builds fine, your api should be a
 
 ---
 
-**!! There are more docker-compose examples under the deployments folder !!**
+For advanced deployment scenarios, consider adding environment-specific `docker-compose.override.yml` files alongside the root `docker-compose.yml`.

--- a/scripts/add-update-db-migrations.ps1
+++ b/scripts/add-update-db-migrations.ps1
@@ -4,6 +4,7 @@ param(
      [string]$commitMessage
  )
 
+$currentDirectory = Get-Location
 $rootDirectory = git rev-parse --show-toplevel
 $hostDirectory = $rootDirectory + '/src/Host'
 Set-Location -Path $hostDirectory

--- a/src/Host/Host.csproj
+++ b/src/Host/Host.csproj
@@ -12,12 +12,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
-    <PackageReference
-      Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers"
-      Version="0.4.421302"
-    >
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.5" />
     <PackageReference Remove="Roslynator.Analyzers" />
     <PackageReference Remove="StyleCop.Analyzers" />

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -20,13 +20,11 @@
     <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.3.9" />
     <PackageReference
       Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"
       Version="10.0.5"
     />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.2.9" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5">
@@ -51,20 +49,11 @@
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.2" />
-    <PackageReference
-      Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers"
-      Version="0.4.421302"
-    >
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Remove="Roslynator.Analyzers" />
     <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Application\Application.csproj" />
     <ProjectReference Include="..\Core\Domain\Domain.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="Catalog\*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/src/Infrastructure/Persistence/Repository/EventAddingRepositoryDecorator.cs
+++ b/src/Infrastructure/Persistence/Repository/EventAddingRepositoryDecorator.cs
@@ -56,12 +56,18 @@ public class EventAddingRepositoryDecorator<T>(IRepository<T> decorated) : IRepo
         return decorated.DeleteRangeAsync(entities, cancellationToken);
     }
 
-    public Task<int> DeleteRangeAsync(
+    public async Task<int> DeleteRangeAsync(
         ISpecification<T> specification,
         CancellationToken cancellationToken = new CancellationToken()
     )
     {
-        throw new NotImplementedException();
+        var entities = await decorated.ListAsync(specification, cancellationToken);
+        foreach (var entity in entities)
+        {
+            entity.DomainEvents.Add(EntityDeletedEvent.WithEntity(entity));
+        }
+
+        return await decorated.DeleteRangeAsync(entities, cancellationToken);
     }
 
     // The rest of the methods are simply forwarded.


### PR DESCRIPTION
- EventAddingRepositoryDecorator: implement DeleteRangeAsync(ISpecification)
  instead of throwing NotImplementedException — loads entities first so
  domain events are raised before deletion
- Migration script: capture $currentDirectory before cd-ing to host dir
  so the final Set-Location -Path $currentDirectory actually restores it
- Husky task-runner.json: add "group": "csharpier" so the pre-commit
  hook's --group csharpier filter finds the task instead of silently
  skipping it
- Infrastructure.csproj: remove Microsoft.AspNetCore.Identity 2.3.9
  (superseded by framework reference), Microsoft.AspNetCore.SignalR 1.2.9
  (same), Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers
  (leftover from upgrade tooling), and dangling Catalog\*.json glob
- Host.csproj: remove Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers
- README_DOCKER.md: remove reference to nonexistent deployments/ folder
- CONTRIBUTING.md: replace third-party contact email with repo issue tracker
- CLAUDE.md: correct tech stack version table to match actual .csproj values

https://claude.ai/code/session_01LSnvc4ioMVPsgyJPHjoWyk